### PR TITLE
Add proxy support

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,23 @@ async def main():
     await steam.login_to_steam()
 ```
 
+## Proxy usage
+
+The library supports the usage of HTTP/HTTPS proxies.
+
+```python
+from pysteamauth.auth import Steam
+
+async def main():
+    steam = Steam(
+        login='login', 
+        password='password',
+        proxy="http://ip:port"
+    )
+    
+    await steam.login_to_steam()
+```
+
 ## Error processing
 
 ```python

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools>=42", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/pysteamauth/auth/steam.py
+++ b/pysteamauth/auth/steam.py
@@ -53,6 +53,7 @@ class Steam:
         device_id: Optional[str] = None,
         cookie_storage: Optional[CookieStorageAbstract] = None,
         request_strategy: Optional[RequestStrategyAbstract] = None,
+        proxy: Optional[str] = None,
     ):
         self._login = login
         self._steamid = steamid
@@ -60,8 +61,9 @@ class Steam:
         self._shared_secret = shared_secret
         self._identity_secret = identity_secret
         self._device_id = device_id
-        self._requests = request_strategy if request_strategy is not None else BaseRequestStrategy()
+        self._requests = request_strategy if request_strategy is not None else BaseRequestStrategy(proxy)
         self._storage = cookie_storage if cookie_storage is not None else BaseCookieStorage()
+        self._proxy = proxy
 
     @property
     def steamid(self) -> int:

--- a/pysteamauth/auth/steam.py
+++ b/pysteamauth/auth/steam.py
@@ -303,7 +303,7 @@ class Steam:
             ),
             headers=headers,
         )
-        return FinalizeLoginStatus.parse_raw(response)
+        return FinalizeLoginStatus.validate_json(response)
 
     async def _set_token(self, url: str, nonce: str, auth: str, steamid: int) -> None:
         await self._requests.request(

--- a/pysteamauth/auth/steam.py
+++ b/pysteamauth/auth/steam.py
@@ -303,7 +303,7 @@ class Steam:
             ),
             headers=headers,
         )
-        return FinalizeLoginStatus.validate_json(response)
+        return FinalizeLoginStatus.model_validate_json(response)
 
     async def _set_token(self, url: str, nonce: str, auth: str, steamid: int) -> None:
         await self._requests.request(

--- a/pysteamauth/auth/steam.py
+++ b/pysteamauth/auth/steam.py
@@ -287,6 +287,10 @@ class Steam:
         return CAuthentication_PollAuthSessionStatus_Response.FromString(response)
 
     async def _finalize_login(self, refresh_token: str, sessionid: str) -> FinalizeLoginStatus:
+        headers = {
+            "Referer": "https://steamcommunity.com/",
+            "Origin": "https://steamcommunity.com",
+        }
         response = await self._requests.text(
             method='POST',
             url='https://login.steampowered.com/jwt/finalizelogin',
@@ -297,6 +301,7 @@ class Steam:
                     ('redir', 'https://steamcommunity.com/login/home/?goto='),
                 ],
             ),
+            headers=headers,
         )
         return FinalizeLoginStatus.parse_raw(response)
 

--- a/pysteamauth/base/request.py
+++ b/pysteamauth/base/request.py
@@ -16,8 +16,9 @@ from pysteamauth.errors import check_steam_error
 
 class BaseRequestStrategy(RequestStrategyAbstract):
 
-    def __init__(self):
+    def __init__(self, proxy: Optional[str] = None):
         self._session: Optional[ClientSession] = None
+        self._proxy = proxy
 
     def __del__(self):
         if self._session:
@@ -37,7 +38,7 @@ class BaseRequestStrategy(RequestStrategyAbstract):
     async def request(self, url: str, method: str, **kwargs: Any) -> ClientResponse:
         if self._session is None:
             self._session = self._create_session()
-        response = await self._session.request(method, url, **kwargs)
+        response = await self._session.request(method, url, proxy=self._proxy, **kwargs)
         error = response.headers.get('X-eresult')
         if error:
             check_steam_error(int(error))

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 requirements = [
     'aiohttp',
     'protobuf==5.28.2',
-    'pydantic==1.9',
+    'pydantic>=2',
     'rsa==4.7',
     'bitstring==3.1.2',
     'urllib3==2.2.2',

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import setuptools
 from setuptools import setup
 
 requirements = [
-    'aiohttp==3.10.2',
+    'aiohttp',
     'protobuf==5.28.2',
     'pydantic==1.9',
     'rsa==4.7',

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,6 @@
 import setuptools
 from setuptools import setup
 
-
 requirements = [
     'aiohttp==3.10.2',
     'protobuf==5.28.2',
@@ -10,7 +9,6 @@ requirements = [
     'bitstring==3.1.2',
     'urllib3==2.2.2',
 ]
-
 
 setup(
     name='pysteamauth',
@@ -26,6 +24,5 @@ setup(
     zip_safe=False,
     python_requires='>=3.9',
     install_requires=requirements,
-    setup_requires=requirements,
     include_package_data=True,
 )


### PR DESCRIPTION
Adds support for using proxies.

Example usage:
```python
from pysteamauth.auth import Steam

async def main():
    steam = Steam(
        login='login', 
        password='password',
        proxy="http://ip:port"
    )
    
    await steam.login_to_steam()
```