### PR TITLE
Release v1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [v1.1.0 (2024-20-20)](https://github.com/sometastycake/pysteamauth/releases/tag/v1.1.0)
+
+- Removed support python 3.7 and python 3.8
+- Use strict versions of dependencies
+- Bump versions of dependencies
+
 ## [v1.0.0 (2023-01-22)](https://github.com/sometastycake/pysteamauth/releases/tag/v1.0.0)
 
 - `get_steam_guard` method is classmethod now

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Asynchronous python library for Steam authorization using protobuf
 
-[![pypi: package](https://img.shields.io/badge/pypi-1.0.0-blue)](https://pypi.org/project/pysteamauth/)
+[![pypi: package](https://img.shields.io/badge/pypi-1.1.0-blue)](https://pypi.org/project/pysteamauth/)
 [![Python: versions](
-https://img.shields.io/badge/python-3.7%20%7C%203.8%20%7C%203.9%20%7C%203.10-blue)]()
+https://img.shields.io/badge/python-3.9%20%7C%203.10%20%7C%203.11%20%7C%203.12-blue)]()
 
 
 ## Install

--- a/setup.py
+++ b/setup.py
@@ -3,18 +3,18 @@ from setuptools import setup
 
 
 requirements = [
-    'aiohttp>=3.5.0',
-    'protobuf>3.18.3',
-    'pydantic>=1.5',
-    'rsa>=4.0',
-    'bitstring>=3.1.2',
-    'urllib3>=1.26.14',
+    'aiohttp==3.10.2',
+    'protobuf==5.28.2',
+    'pydantic==1.9',
+    'rsa==4.7',
+    'bitstring==3.1.2',
+    'urllib3==2.2.2',
 ]
 
 
 setup(
     name='pysteamauth',
-    version='1.0.0',
+    version='1.1.0',
     url='https://github.com/sometastycake/pysteamauth',
     license='MIT',
     author='Mike M',
@@ -24,7 +24,7 @@ setup(
     long_description_content_type='text/markdown',
     packages=setuptools.find_packages(),
     zip_safe=False,
-    python_requires='>=3.7',
+    python_requires='>=3.9',
     install_requires=requirements,
     setup_requires=requirements,
     include_package_data=True,


### PR DESCRIPTION
- Removed support python 3.7 and python 3.8
- Use strict versions of dependencies
- Bump versions of dependencies